### PR TITLE
Refactoring code in install.js and increasing coverage and console log in flag.js 

### DIFF
--- a/src/flags.js
+++ b/src/flags.js
@@ -19,7 +19,6 @@ const utils = require('./utils');
 const batch = require('./batch');
 
 const Flags = module.exports;
-
 Flags._states = new Map([
 	['open', {
 		label: '[[flags:state-open]]',
@@ -390,6 +389,7 @@ Flags.deleteNote = async function (flagId, datetime) {
 };
 
 Flags.create = async function (type, id, uid, reason, timestamp, forceFlag = false) {
+	console.log('Flags.created RAYYAN');
 	let doHistoryAppend = false;
 	if (!timestamp) {
 		timestamp = Date.now();

--- a/src/install.js
+++ b/src/install.js
@@ -47,10 +47,25 @@ questions.optional = [
 	},
 ];
 
+// gpt assisted code
 function checkSetupFlagEnv() {
 	let setupVal = install.values;
+	const envConfMap = getEnvConfMap();
+	if (hasRelevantEnvVars(envConfMap)) {
+		winston.info('[install/checkSetupFlagEnv] checking env vars for setup info...');
+		setupVal = setUpValuesFromEnv(setupVal, envConfMap);
+	}
+	setupVal = getSetupValuesFromJson(setupVal);
 
-	const envConfMap = {
+	if (setupVal && typeof setupVal === 'object') {
+		validateSetupValues(setupVal);
+	} else if (nconf.get('database')) {
+		setDatabaseValues();
+	}
+}
+
+function getEnvConfMap() {
+	return {
 		CONFIG: 'config',
 		NODEBB_CONFIG: 'config',
 		NODEBB_URL: 'url',
@@ -66,89 +81,104 @@ function checkSetupFlagEnv() {
 		NODEBB_DB_NAME: 'database',
 		NODEBB_DB_SSL: 'ssl',
 	};
+}
 
-	// Set setup values from env vars (if set)
+function hasRelevantEnvVars(envConfMap) {
 	const envKeys = Object.keys(process.env);
-	if (Object.keys(envConfMap).some(key => envKeys.includes(key))) {
-		winston.info('[install/checkSetupFlagEnv] checking env vars for setup info...');
-		setupVal = setupVal || {};
+	return Object.keys(envConfMap).some(key => envKeys.includes(key));
+}
 
-		Object.entries(process.env).forEach(([evName, evValue]) => { // get setup values from env
-			if (evName.startsWith('NODEBB_DB_')) {
-				setupVal[`${process.env.NODEBB_DB}:${envConfMap[evName]}`] = evValue;
-			} else if (evName.startsWith('NODEBB_')) {
-				setupVal[envConfMap[evName]] = evValue;
-			}
-		});
+function setUpValuesFromEnv(setupVal, envConfMap) {
+	setupVal = setupVal || {};
+	Object.entries(process.env).forEach(([evName, evValue]) => {
+		if (evName.startsWith('NODEBB_DB_')) {
+			setupVal[`${process.env.NODEBB_DB}:${envConfMap[evName]}`] = evValue;
+		} else if (evName.startsWith('NODEBB_')) {
+			setupVal[envConfMap[evName]] = evValue;
+		}
+	});
+	setupVal['admin:password:confirm'] = setupVal['admin:password'];
+	return setupVal;
+}
 
-		setupVal['admin:password:confirm'] = setupVal['admin:password'];
-	}
-
-	// try to get setup values from json, if successful this overwrites all values set by env
-	// TODO: better behaviour would be to support overrides per value, i.e. in order of priority (generic pattern):
-	//       flag, env, config file, default
+function getSetupValuesFromJson(setupVal) {
 	try {
 		if (nconf.get('setup')) {
 			const setupJSON = JSON.parse(nconf.get('setup'));
-			setupVal = { ...setupVal, ...setupJSON };
+			return { ...setupVal, ...setupJSON };
 		}
 	} catch (err) {
 		winston.error('[install/checkSetupFlagEnv] invalid json in nconf.get(\'setup\'), ignoring setup values from json');
 	}
+	return setupVal;
+}
 
-	if (setupVal && typeof setupVal === 'object') {
-		if (setupVal['admin:username'] && setupVal['admin:password'] && setupVal['admin:password:confirm'] && setupVal['admin:email']) {
-			install.values = setupVal;
-		} else {
-			winston.error('[install/checkSetupFlagEnv] required values are missing for automated setup:');
-			if (!setupVal['admin:username']) {
-				winston.error('  admin:username');
-			}
-			if (!setupVal['admin:password']) {
-				winston.error('  admin:password');
-			}
-			if (!setupVal['admin:password:confirm']) {
-				winston.error('  admin:password:confirm');
-			}
-			if (!setupVal['admin:email']) {
-				winston.error('  admin:email');
-			}
-
-			process.exit();
-		}
-	} else if (nconf.get('database')) {
-		install.values = install.values || {};
-		install.values.database = nconf.get('database');
+function validateSetupValues(setupVal) {
+	if (setupVal['admin:username'] && setupVal['admin:password'] && setupVal['admin:password:confirm'] && setupVal['admin:email']) {
+		install.values = setupVal;
+	} else {
+		winston.error('[install/checkSetupFlagEnv] required values are missing for automated setup:');
+		logMissingSetupValues(setupVal);
+		process.exit();
 	}
 }
 
+function logMissingSetupValues(setupVal) {
+	if (!setupVal['admin:username']) winston.error('  admin:username');
+	if (!setupVal['admin:password']) winston.error('  admin:password');
+	if (!setupVal['admin:password:confirm']) winston.error('  admin:password:confirm');
+	if (!setupVal['admin:email']) winston.error('  admin:email');
+}
+
+function setDatabaseValues() {
+	install.values = install.values || {};
+	install.values.database = nconf.get('database');
+}
+
+// GPT assisted code
 function checkCIFlag() {
-	let ciVals;
-	try {
-		ciVals = JSON.parse(nconf.get('ci'));
-	} catch (e) {
-		ciVals = undefined;
-	}
+	const ciVals = getCIVals();
 
-	if (ciVals && ciVals instanceof Object) {
-		if (ciVals.hasOwnProperty('host') && ciVals.hasOwnProperty('port') && ciVals.hasOwnProperty('database')) {
-			install.ciVals = ciVals;
-		} else {
-			winston.error('[install/checkCIFlag] required values are missing for automated CI integration:');
-			if (!ciVals.hasOwnProperty('host')) {
-				winston.error('  host');
-			}
-			if (!ciVals.hasOwnProperty('port')) {
-				winston.error('  port');
-			}
-			if (!ciVals.hasOwnProperty('database')) {
-				winston.error('  database');
-			}
-
-			process.exit();
-		}
+	if (isValidCIVals(ciVals)) {
+		install.ciVals = ciVals;
+	} else {
+		handleMissingCIValues(ciVals);
 	}
 }
+
+function getCIVals() {
+	try {
+		return JSON.parse(nconf.get('ci'));
+	} catch (e) {
+		return undefined;
+	}
+}
+
+function isValidCIVals(ciVals) {
+	return ciVals && ciVals instanceof Object &&
+        ciVals.hasOwnProperty('host') &&
+        ciVals.hasOwnProperty('port') &&
+        ciVals.hasOwnProperty('database');
+}
+
+function handleMissingCIValues(ciVals) {
+	winston.error('[install/checkCIFlag] required values are missing for automated CI integration:');
+
+	if (!ciVals.hasOwnProperty('host')) {
+		winston.error('  host');
+	}
+
+	if (!ciVals.hasOwnProperty('port')) {
+		winston.error('  port');
+	}
+
+	if (!ciVals.hasOwnProperty('database')) {
+		winston.error('  database');
+	}
+
+	process.exit();
+}
+
 
 async function setupConfig() {
 	const configureDatabases = require('../install/databases');

--- a/test/flags.js
+++ b/test/flags.js
@@ -1169,9 +1169,41 @@ describe('Flags', () => {
 					assert.strictEqual(statusCode, 200, `${opts.method.toUpperCase()} ${opts.uri} => ${statusCode}`);
 				}
 			});
+			// COPILOT ASSISTED CODE
+			describe('.getFlagIdByTarget()', () => {
+				it('should return the flagId for a post', async () => {
+					// Create a new post
+					const { postData } = await Topics.post({
+						cid: category.cid,
+						uid: uid1,
+						title: utils.generateUUID(),
+						content: utils.generateUUID(),
+					});
+					const postId = postData.pid;
+
+					const flagId = await Flags.create('post', postId, uid1, 'Test flag');
+					const result = await Flags.getFlagIdByTarget('post', postId);
+					assert.strictEqual(result, flagId.flagId);
+					await Flags.purge([flagId.flagId]); // Cleanup
+				});
+
+				it('should return the flagId for a user', async () => {
+					const userId = uid1;
+					const flagId = await Flags.create('user', userId, uid1, 'Test flag');
+					const result = await Flags.getFlagIdByTarget('user', userId);
+					assert.strictEqual(result, flagId.flagId);
+					await Flags.purge([flagId.flagId]); // Cleanup
+				});
+
+				it('should throw an error when type is invalid', async () => {
+					await assert.rejects(
+						Flags.getFlagIdByTarget('invalidType', 'someId'),
+						new Error('[[error:invalid-data]]')
+					);
+				});
+			});
 
 			it('should NOT allow access to privileged endpoints to moderators if the flag target is a post in a cid they DO NOT moderate', async () => {
-				// This is a new category the user will moderate, but the flagged post is in a different category
 				const { cid } = await Categories.create({
 					name: utils.generateUUID(),
 				});


### PR DESCRIPTION
Refactored 2 different functions from their complexities (22 and 16) to a complexity of at least 15.
I broke the code down and put many of the conditional statements into different helper functions.
This in turn helped to reduce the complexity of the function, as instead of doing the complex conditional logic, it simply had to make a function call.
Hence reducing the overall complexity.
The file path is src/install.js


I was able to increase the overall code coverage of the flag.js file.

83.26% Statements 408/490 67.34% Branches 165/245 82.69% Functions 86/104 83.87% Lines 390/465

85.3% Statements 418/490 71.02% Branches 174/245 84.61% Functions 88/104 86.02% Lines 400/465

This was indicated in the npm run test locally, and on the code coverage tool, and shown to Professor Eduardo as well.

Further, I addded a console log to the flag.js file and it was shown after i triggered the code, by flagging a blog post or annoucement.

The file path is src/flag.js