### PR TITLE
Private Posts: Added a checkbox button to the front-end for posting privately

### DIFF
--- a/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
+++ b/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
@@ -654,6 +654,8 @@ define('composer', [
 		var thumbEl = postContainer.find('input#topic-thumb-url');
 		// Get the checkbox for anonymous posts
 		var anonymousCheckbox = postContainer.find('#anonymousPost');
+		// To store the data for private post checkbox in a variable
+		var privateCheckbox = postContainer.find('postPrivateCheckbox');
 		var onComposeRoute = postData.hasOwnProperty('template') && postData.template.compose === true;
 		const submitBtn = postContainer.find('.composer-submit');
 
@@ -704,10 +706,16 @@ define('composer', [
 			return composerAlert(post_uuid, '[[error:scheduling-to-past]]');
 		}
 
+		if (isPrivate.prop('checked')) {
+			// If the private checkbox is checked, add the private flag to the payload
+			postType = 'private';
+		}
+
 		let composerData = {
 			// Include the anonymous flag
 			isAnonymous: anonymousCheckbox.is(':checked'),
 			uuid: post_uuid,
+			postType: postType
 		};
 		let method = 'post';
 		let route = '';

--- a/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
+++ b/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
@@ -655,7 +655,7 @@ define('composer', [
 		// Get the checkbox for anonymous posts
 		var anonymousCheckbox = postContainer.find('#anonymousPost');
 		// To store the data for private post checkbox in a variable
-		var privateCheckbox = postContainer.find('postPrivateCheckbox');
+		var privateCheckbox = postContainer.find('#postPrivateCheckbox');
 		var onComposeRoute = postData.hasOwnProperty('template') && postData.template.compose === true;
 		const submitBtn = postContainer.find('.composer-submit');
 

--- a/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
+++ b/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
@@ -655,7 +655,7 @@ define('composer', [
 		// Get the checkbox for anonymous posts
 		var anonymousCheckbox = postContainer.find('#anonymousPost');
 		// To store the data for private post checkbox in a variable
-		var privateCheckbox = postContainer.find('#postPrivateCheckbox');
+		var isPrivate = postContainer.find('#postPrivateCheckbox');
 		var onComposeRoute = postData.hasOwnProperty('template') && postData.template.compose === true;
 		const submitBtn = postContainer.find('.composer-submit');
 

--- a/node_modules/nodebb-plugin-composer-default/static/templates/partials/composer-title-container.tpl
+++ b/node_modules/nodebb-plugin-composer-default/static/templates/partials/composer-title-container.tpl
@@ -30,6 +30,12 @@
 		<label class="form-check-label text-body fw-semibold" for="anonymousPost"><i class="fa fa-user-secret"></i> <span class="d-none d-md-inline"><strong>Anonymous Post</strong></span></label>
 	</div>
 
+	<!-- Add checkbox for private posting -->
+	<div class="form-check form-switch">
+		<input class="form-check-input" type="checkbox" id="postPrivateCheckbox" data-field="privatePost">
+		<label class="form-check-label text-body fw-semibold" for="privatePost"><i class="fa fa-lock"></i> <span class="d-none d-md-inline"><strong>Private Post</strong></span></label>
+	</div>
+
 	<div class="{{{ if !template.compose }}}d-none d-md-flex{{{ else }}}d-flex{{{ end }}} action-bar gap-1 align-items-center">
 		<button class="btn btn-sm btn-link text-body fw-semibold composer-minimize" data-action="hide"><i class="fa fa-angle-down"></i> <span class="d-none d-md-inline">[[topic:composer.hide]]</span></button>
 		<button class="btn btn-sm btn-link composer-discard text-body fw-semibold" data-action="discard"><i class="fa fa-trash"></i> <span class="d-none d-md-inline">[[topic:composer.discard]]</button>

--- a/node_modules/nodebb-plugin-composer-default/static/templates/partials/composer-title-container.tpl
+++ b/node_modules/nodebb-plugin-composer-default/static/templates/partials/composer-title-container.tpl
@@ -32,8 +32,8 @@
 
 	<!-- Add checkbox for private posting -->
 	<div class="form-check form-switch">
-		<input class="form-check-input" type="checkbox" id="postPrivateCheckbox" data-field="privatePost">
-		<label class="form-check-label text-body fw-semibold" for="privatePost"><i class="fa fa-lock"></i> <span class="d-none d-md-inline"><strong>Private Post</strong></span></label>
+		<input class="form-check-input" type="checkbox" id="postPrivateCheckbox" data-field="postPrivateCheckbox">
+		<label class="form-check-label text-body fw-semibold" for="postPrivateCheckbox"><i class="fa fa-lock"></i> <span class="d-none d-md-inline"><strong>Private Post</strong></span></label>
 	</div>
 
 	<div class="{{{ if !template.compose }}}d-none d-md-flex{{{ else }}}d-flex{{{ end }}} action-bar gap-1 align-items-center">


### PR DESCRIPTION
# Description #
Resolves #50 
This checkbox button that allows students to create private posts that only certain users (e.g., moderators/instructors) can see. This gives students a secure way to ask questions, get clarification, or discuss sensitive issues without their peers being involved. It ensures students can communicate directly and privately with instructors about private topics.
___________________________________________________________________________________________________________
# Implementation #

- Added a checkbox button in the template file for composer view for user interaction to specify private posting
- Added a lock image beside the checkbox button
- Stored and processed the checkbox data in a variable so that it can be tracked and used for verification at the back-end
___________________________________________________________________________________________________________
<img width="1424" alt="Screenshot 2024-10-09 at 12 39 01" src="https://github.com/user-attachments/assets/9d0377cd-8e3f-4015-849b-dde178e0e42d">
