### PR TITLE
Filter Bad Words: automatic testing for posts with and without bad words.

### DIFF
--- a/test/topics.js
+++ b/test/topics.js
@@ -95,7 +95,21 @@ describe('Topic\'s', () => {
 
 
 		
-
+		// TEST CASE FOR BAD WORDS, Hello is not a bad word but the hell in Hello should not trigger any exception
+		it('should create a new topic with inappropriate word in a normal word', (done) => {
+			console.log("#############################################################################################33")
+			topics.post({
+				uid: topic.userId,
+				title: topic.title,
+				content: "Hello SHOULD not flag anything even if the first 4 letters can be a bad word",
+				cid: topic.categoryId,
+			}, (err, result) => {
+				assert.ifError(err);
+				assert(result);
+				topic.tid = result.topicData.tid;
+				done();
+			});
+		});
 
 		it('should get post count', async () => {
 			const count = await socketTopics.postcount({ uid: adminUid }, topic.tid);

--- a/test/topics.js
+++ b/test/topics.js
@@ -162,6 +162,54 @@ describe('Topic\'s', () => {
 		});
 
 
+		// TEST CASE FOR BAD WORDS, "Arabic" is not a bad word
+		it('should create a new topic with inappropriate word in a normal word "Arabic"', (done) => {
+			console.log('#############################################################################################33');
+			topics.post({
+				uid: topic.userId,
+				title: topic.title,
+				content: 'hello my name is Arabic',
+				cid: topic.categoryId,
+			}, (err, result) => {
+				assert.ifError(err);
+				assert(result);
+				topic.tid = result.topicData.tid;
+				done();
+			});
+		});
+
+
+		// TEST CASE FOR BAD WORDS, "ARABIC" is not a bad word
+		it('should create a new topic with inappropriate word in a normal word "ARABIC"', (done) => {
+			console.log('#############################################################################################33');
+			topics.post({
+				uid: topic.userId,
+				title: topic.title,
+				content: 'hello my name is ARABIC',
+				cid: topic.categoryId,
+			}, (err, result) => {
+				assert.ifError(err);
+				assert(result);
+				topic.tid = result.topicData.tid;
+				done();
+			});
+		});
+
+		// TEST CASE FOR BAD WORDS, "arabic" is not a bad word
+		it('should create a new topic with inappropriate word in a normal word "arabic"', (done) => {
+			console.log('#############################################################################################33');
+			topics.post({
+				uid: topic.userId,
+				title: topic.title,
+				content: 'hello my name is arabic',
+				cid: topic.categoryId,
+			}, (err, result) => {
+				assert.ifError(err);
+				assert(result);
+				topic.tid = result.topicData.tid;
+				done();
+			});
+		});
 
 		
 		it('should get post count', async () => {

--- a/test/topics.js
+++ b/test/topics.js
@@ -77,18 +77,18 @@ describe('Topic\'s', () => {
 			});
 		});
 
-		//TEST CASE FOR BAD WORDS, arab is a bad word
-		it('should create a new topic with inappropriate words', (done) => {
-			console.log("#############################################################################################33")
+		// TEST CASE FOR BAD WORDS, "arab" is a bad word
+		// COPILOT ASSISTED CODE
+		it('should not create a new topic with inappropriate words', (done) => {
 			topics.post({
 				uid: topic.userId,
 				title: topic.title,
 				content: "helooooo my name is arab",
 				cid: topic.categoryId,
 			}, (err, result) => {
-				assert.ifError(err);
-				assert(result);
-				topic.tid = result.topicData.tid;
+				assert(err, 'Expected an error to be thrown');
+				assert.strictEqual(err.message, '[[error:bad-word-detected]]', 'Expected bad word detection error');
+				assert(!result, 'Expected no result due to bad word detection');
 				done();
 			});
 		});
@@ -101,7 +101,7 @@ describe('Topic\'s', () => {
 			topics.post({
 				uid: topic.userId,
 				title: topic.title,
-				content: "Hello SHOULD not flag anything even if the first 4 letters can be a bad word",
+				content: "hello should not flag anything even though the first 4 letters can be a bad word",
 				cid: topic.categoryId,
 			}, (err, result) => {
 				assert.ifError(err);

--- a/test/topics.js
+++ b/test/topics.js
@@ -83,7 +83,7 @@ describe('Topic\'s', () => {
 			topics.post({
 				uid: topic.userId,
 				title: topic.title,
-				content: "helooooo my name is arab",
+				content: 'helooooo my name is arab',
 				cid: topic.categoryId,
 			}, (err, result) => {
 				assert(err, 'Expected an error to be thrown');
@@ -94,14 +94,14 @@ describe('Topic\'s', () => {
 		});
 
 
-		
+
 		// TEST CASE FOR BAD WORDS, Hello is not a bad word but the hell in Hello should not trigger any exception
 		it('should create a new topic with inappropriate word in a normal word', (done) => {
-			console.log("#############################################################################################33")
+			console.log('#############################################################################################33');
 			topics.post({
 				uid: topic.userId,
 				title: topic.title,
-				content: "hello should not flag anything even though the first 4 letters can be a bad word",
+				content: 'hello should not flag anything even though the first 4 letters can be a bad word',
 				cid: topic.categoryId,
 			}, (err, result) => {
 				assert.ifError(err);

--- a/test/topics.js
+++ b/test/topics.js
@@ -77,6 +77,26 @@ describe('Topic\'s', () => {
 			});
 		});
 
+		//TEST CASE FOR BAD WORDS, arab is a bad word
+		it('should create a new topic with inappropriate words', (done) => {
+			console.log("#############################################################################################33")
+			topics.post({
+				uid: topic.userId,
+				title: topic.title,
+				content: "helooooo my name is arab",
+				cid: topic.categoryId,
+			}, (err, result) => {
+				assert.ifError(err);
+				assert(result);
+				topic.tid = result.topicData.tid;
+				done();
+			});
+		});
+
+
+		
+
+
 		it('should get post count', async () => {
 			const count = await socketTopics.postcount({ uid: adminUid }, topic.tid);
 			assert.strictEqual(count, 1);

--- a/test/topics.js
+++ b/test/topics.js
@@ -145,7 +145,21 @@ describe('Topic\'s', () => {
 		});
 
 
-
+		// TEST CASE FOR BAD WORDS, "araB" is a bad word
+		// COPILOT ASSISTED CODE
+		it('should not create a new topic with inappropriate words "araB"', (done) => {
+			topics.post({
+				uid: topic.userId,
+				title: topic.title,
+				content: 'helooooo my name is araB',
+				cid: topic.categoryId,
+			}, (err, result) => {
+				assert(err, 'Expected an error to be thrown');
+				assert.strictEqual(err.message, '[[error:bad-word-detected, araB]]', 'Expected bad word detection error');
+				assert(!result, 'Expected no result due to bad word detection');
+				done();
+			});
+		});
 
 
 

--- a/test/topics.js
+++ b/test/topics.js
@@ -128,6 +128,21 @@ describe('Topic\'s', () => {
 			});
 		});
 
+		// TEST CASE FOR BAD WORDS, "ARAB" is a bad word
+		// COPILOT ASSISTED CODE
+		it('should not create a new topic with inappropriate words "ARAB"', (done) => {
+			topics.post({
+				uid: topic.userId,
+				title: topic.title,
+				content: 'helooooo my name is ARAB',
+				cid: topic.categoryId,
+			}, (err, result) => {
+				assert(err, 'Expected an error to be thrown');
+				assert.strictEqual(err.message, '[[error:bad-word-detected, ARAB]]', 'Expected bad word detection error');
+				assert(!result, 'Expected no result due to bad word detection');
+				done();
+			});
+		});
 
 
 

--- a/test/topics.js
+++ b/test/topics.js
@@ -87,7 +87,7 @@ describe('Topic\'s', () => {
 				cid: topic.categoryId,
 			}, (err, result) => {
 				assert(err, 'Expected an error to be thrown');
-				assert.strictEqual(err.message, '[[error:bad-word-detected]]', 'Expected bad word detection error');
+				assert.strictEqual(err.message, '[[error:bad-word-detected, arab]]', 'Expected bad word detection error');
 				assert(!result, 'Expected no result due to bad word detection');
 				done();
 			});

--- a/test/topics.js
+++ b/test/topics.js
@@ -93,7 +93,7 @@ describe('Topic\'s', () => {
 			});
 		});
 
-		
+
 
 
 		// TEST CASE FOR BAD WORDS, Hello is not a bad word but the hell in Hello should not trigger any exception
@@ -211,7 +211,7 @@ describe('Topic\'s', () => {
 			});
 		});
 
-		
+
 		it('should get post count', async () => {
 			const count = await socketTopics.postcount({ uid: adminUid }, topic.tid);
 			assert.strictEqual(count, 1);

--- a/test/topics.js
+++ b/test/topics.js
@@ -93,6 +93,7 @@ describe('Topic\'s', () => {
 			});
 		});
 
+		
 
 
 		// TEST CASE FOR BAD WORDS, Hello is not a bad word but the hell in Hello should not trigger any exception
@@ -111,6 +112,29 @@ describe('Topic\'s', () => {
 			});
 		});
 
+		// TEST CASE FOR BAD WORDS, "Arab" is a bad word
+		// COPILOT ASSISTED CODE
+		it('should not create a new topic with inappropriate words "Arab"', (done) => {
+			topics.post({
+				uid: topic.userId,
+				title: topic.title,
+				content: 'helooooo my name is Arab',
+				cid: topic.categoryId,
+			}, (err, result) => {
+				assert(err, 'Expected an error to be thrown');
+				assert.strictEqual(err.message, '[[error:bad-word-detected, Arab]]', 'Expected bad word detection error');
+				assert(!result, 'Expected no result due to bad word detection');
+				done();
+			});
+		});
+
+
+
+
+
+
+
+		
 		it('should get post count', async () => {
 			const count = await socketTopics.postcount({ uid: adminUid }, topic.tid);
 			assert.strictEqual(count, 1);


### PR DESCRIPTION
# Description #
Resolves #68
This feature adds a filtering mechanism that detects posts containing bad words. When bad words are detected, the post triggers the badwords function and the user is notified via an error. The feature ensures inappropriate content is filtered out, maintaining a respectful environment for all users. This pull request addresses the front-end and back-end logic for filtering and notifying users of bad language in their posts.

_________________________________________________________________________________________________________
# Implementation #

- The test file can be run using `npm run test test/topics.js`.
- This tests whether posts containing bad words are caught and rejected before submission.
- The bad words are correctly detected in the post, and an error message is displayed to the user with the bad words they used, and need to change.

_________________________________________________________________________________________________________
